### PR TITLE
linked data directories into /data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       # - "/dev/bus/usb:/dev/bus/usb"
     restart: unless-stopped
     volumes:
-      - app_data:/usr/local/PPB
+      - app_data:/data
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
 


### PR DESCRIPTION
I tried to overcome the problem with the whole installation being copied into the volume.
To solve this I did:
* start the application at build time for 60 seconds to get the initial data directories being created
* added a script part to the entrypoint which check
  - if the asset in the data volume already exists
  - moves the asset to the data volume, if it does not already exist
  - deletes the 'container' asset in the application directory
  - creates a link for the asset in the application directory

This works for the following assets:
* db_cloud
* db_local
* db_remote
* etc
* log
* jre/lib/security/cacerts

Unfortunately the assets cert/ and extcmd/ as links give massive Java errors and prevent the application from starting.

Now also the bind mounts to host directories work :)

Please have a look

CU
Snorre