### PR TITLE
Only data in volume - bind mounts possible

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       # - "/dev/bus/usb:/dev/bus/usb"
     restart: unless-stopped
     volumes:
-      - app_data:/usr/local/PPB
+      - app_data:/data
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -52,5 +52,9 @@ done
 service ppbd start
 service ppbwd start
 
-# to run indefinitely instead of stopping as soon as the previous commands complete
-tail -F /dev/null
+# Trap SIGHUP SIGINT SIGTERM
+trap "exit" 1 2 15
+
+# to run indefinitely instead of stopping as soon as the previous commands complete - wait for children
+tail -F /dev/null & wait
+

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -25,24 +25,25 @@ DATA_VOL="/data"
 INST_LOC="/usr/local/PPB"
 for asset in db_cloud db_local db_remote etc log jre/lib/security/cacerts; do
 #for asset in cert db_cloud db_local db_remote etc extcmd log jre/lib/security/cacerts; do
-	if [ -e $DATA_VOL/$asset ]; then
+	asset_name=$(basename $asset)
+	if [ -e $DATA_VOL/$asset_name ]; then
 		if [ -e $INST_LOC/$asset ]; then
-			echo "$DATA_VOL/$assset existing -> removing $INST_LOC/$asset"
+			echo "$DATA_VOL/$asset_name existing -> removing $INST_LOC/$asset"
 			rm -rf $INST_LOC/$asset
 		else
 			echo "WARNING: As $INST_LOC/$asset does not exist, it seems that service initialization did not run properly at container build"
 		fi
 	elif [ -e $INST_LOC/$asset ]; then
-		echo "$DATA_VOL/$asset not existing, $INST_LOC/$asset exiting -> moving"
+		echo "$DATA_VOL/$asset_name not existing, $INST_LOC/$asset existing -> moving"
 		mv $INST_LOC/$asset $DATA_VOL/
 	else
-		echo "WARNING: $asset not found"
+		echo "WARNING: $asset_name ($asset) not found in $DATA_VOL or $INST_LOC"
 		echo
 		continue
 	fi
 
-	echo "Creating Link $INST_LOC/$asset -> $DATA_VOL/$asset"
-	ln -s $DATA_VOL/$asset $INST_LOC/$asset
+	echo "Creating Link $INST_LOC/$asset -> $DATA_VOL/$asset_name"
+	ln -s $DATA_VOL/$asset_name $INST_LOC/$asset
 	echo
 done
 


### PR DESCRIPTION
Hi Nathan,

I tried to overcome the problem with the whole installation being copied into the volume.

To solve this I did:
* start the application at build time for 60 seconds to get the initial data directories being created
* added a script part to the entrypoint which checks:
  - if the asset in the data volume already exists
  - moves the asset to the data volume, if it does not already exist
  - deletes the 'container' asset in the application directory
  - creates a link for the asset in the application directory

This works for the following assets:
* db_cloud
* db_local
* db_remote
* etc
* log
* jre/lib/security/cacerts

Unfortunately the assets cert/ and extcmd/ as links give massive Java errors and prevent the application from starting. So these directories would need an additional bind mount or volume.

Now also the bind mounts to host directories work :)

Please have a look and merge if you like it.

CU
Snorre